### PR TITLE
Fix deprecation warning when using Rails 6 in zeitwerk mode

### DIFF
--- a/lib/simple_google_auth/engine.rb
+++ b/lib/simple_google_auth/engine.rb
@@ -1,8 +1,10 @@
 module SimpleGoogleAuth
   class Engine < ::Rails::Engine
     initializer "simple_google_auth.load_helpers" do
-      ActionController::Base.send :include, SimpleGoogleAuth::Controller
-      ActionController::Base.send :helper_method, :google_auth_data
+      ActiveSupport.on_load(:action_controller) do
+        include SimpleGoogleAuth::Controller
+        helper_method :google_auth_data
+      end
     end
   end
 end


### PR DESCRIPTION
The engine initialization was causing this error to be logged:
DEPRECATION WARNING: Initialization autoloaded the constants
ActionText::ContentHelper and ActionText::TagHelper.

see this rails issue for mroe info:
https://github.com/rails/rails/issues/36546